### PR TITLE
fix(login): use the correct login endpoint

### DIFF
--- a/lib/Orchestrator.js
+++ b/lib/Orchestrator.js
@@ -177,7 +177,7 @@ Orchestrator.prototype._login = function (callback) {
         isSecure: options.isSecure,
         invalidCertificate: options.invalidCertificate,
         port: options.port,
-        path: pathModule.join(options.path, '/api/Account'),
+        path: pathModule.join(options.path, '/api/Account/Authenticate'),
         agent: this._agent
     };
     loginRequestData = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uipath-orchestrator",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "UiPath Orchestrator Client for Node.JS",
   "repository": {
     "type": "git",


### PR DESCRIPTION
and bump version

the "shortened" version only works in the current version of Orchestrator but will be deprecated (hopefully) in v2020.10